### PR TITLE
FM-063 update branch triggers in CI/CD and deploy workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main ]
+    branches: [ develop, release ]
   pull_request:
-    branches: [ main ]
+    branches: [ release ]
 
 jobs:
   validate:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,12 +2,12 @@ name: Deploy
 
 on:
   push:
-    branches: [ main ]
+    branches: [ release ]
   workflow_run:
     workflows: ["CI/CD Pipeline"]
     types:
       - completed
-    branches: [ main ]
+    branches: [ release ]
 
 # Add permissions block
 permissions:


### PR DESCRIPTION
### 📌 Summary

This PR introduces changes related to the GitHub Actions workflows, updating their trigger branches to match the new `develop` and `release` flow.

---

### 📄 Changes Included

- Updated `ci-cd.yml` to trigger on pushes to `develop` and `release`
- Updated `deploy.yml` to trigger deploys only from `release`
- Removed references to the deprecated `main` branch in both workflows

---

### 🚀 Why This is Needed

These updates ensure that the CI/CD and deploy pipelines are aligned with the new branching strategy (`develop` for active development, `release` for production). This helps streamline deployments and testing, and avoids confusion with the old `main`-based configuration.

---

